### PR TITLE
Break spaces of OCR description

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -309,6 +309,7 @@ Gyazo Plugin Styles
 
 .gyazo-metadata-value {
 	word-break: break-word;
+	white-space: break-spaces;
 }
 
 .gyazo-title-desc-container {


### PR DESCRIPTION
# Break spaces of OCR description

This PR improves the preview of OCR result in detail view.

## Changes

- Add `line-break: break-spaces` to `.gyazo-metadata-value` class style

## Fixes

- Lines of OCR description are broken at newline characters properly.

## Screenshot

[![Image from Gyazo](https://t.gyazo.com/teams/nota/4704ddec75020d9c3e57b8f0633bc841.png)](https://nota.gyazo.com/4704ddec75020d9c3e57b8f0633bc841)