### PR TITLE
chore: remove unused import for translations in settings

### DIFF
--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,6 +1,5 @@
 import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
 import GyazoPlugin from '../../main';
-import { translations } from '../i18n/index';
 import { GyazoApi } from '../api/index';
 
 export class GyazoSettingTab extends PluginSettingTab {


### PR DESCRIPTION
This pull request includes a small change to the `src/settings/index.ts` file. The change removes an unused import for `translations` from the `../i18n/index` module to clean up the code.