### PR TITLE
chore: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           cache: "npm"
@@ -29,10 +29,10 @@ jobs:
   tsc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           cache: "npm"

--- a/.github/workflows/pinact.yml
+++ b/.github/workflows/pinact.yml
@@ -1,0 +1,21 @@
+name: Check Pinned Actions
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  push:
+    branches:
+      - "main"
+
+jobs:
+  check-pinned-actions:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check GitHub Actions are pinned to commit hashes
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"
+          verify: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
 


### PR DESCRIPTION
## Summary

- Pin GitHub Actions versions to commit hashes in existing workflows (`lint.yml`, `release.yml`)
- Add `pinact.yml` workflow to continuously verify that Actions are pinned on PRs and pushes to `main`

## Changes

- `.github/workflows/lint.yml`: Pin `actions/checkout` and `actions/setup-node` to commit hashes
- `.github/workflows/release.yml`: Pin `actions/checkout` and `actions/setup-node` to commit hashes
- `.github/workflows/pinact.yml`: New workflow using `suzuki-shunsuke/pinact-action` to check pinned Actions